### PR TITLE
these patches are for the upcoming camlp5 that will be compatible with ocaml 4.14.0

### DIFF
--- a/src/lib/camlp5/Makefile
+++ b/src/lib/camlp5/Makefile
@@ -11,7 +11,7 @@ pa_scheme:
 
 pr_o:
 	cppo pr_o.cppo.ml -o pr_o.ml
-	camlp5 pa_r.cmo pa_rp.cmo pa_macro.cmo q_MLast.cmo pa_extfun.cmo pa_extprint.cmo pa_pprintf.cmo pr_o.cmo pr_o.ml -o ../pr_o.ml
+	camlp5 pa_r.cmo pa_rp.cmo pa_macro.cmo q_MLast.cmo pa_extfun.cmo pa_extprint.cmo pa_pprintf.cmo q_MLast.cmo pr_o.cmo pr_o.ml -o ../pr_o.ml
 
 pr_dump:
 	cppo pr_dump.cppo.ml -o pr_dump.ml

--- a/src/lib/camlp5/pa_schemer.orig.ml
+++ b/src/lib/camlp5/pa_schemer.orig.ml
@@ -1578,8 +1578,8 @@ and object_field_list_se sel =
 and constructor_declaration_se =
   fun
   [ Sexpr loc [Suid _ ci :: sel] →
-      (loc, <:vala< (rename_id ci) >>, <:vala< (List.map ctyp_se sel) >>,
-       <:vala< None >>, <:vala< [] >>)
+      <:constructor< $uid:(rename_id ci)$ of $list:(List.map ctyp_se sel)$ >>
+
   | se → error se "constructor_declaration" ]
 and variant_declaration_se =
   fun

--- a/src/lib/camlp5/pr_o.orig.ml
+++ b/src/lib/camlp5/pr_o.orig.ml
@@ -667,7 +667,11 @@ value extension_constructor loc pc ec = match ec with [
 value has_ecs_with_params vdl =
   List.exists
     (fun [
-       MLast.EcTuple _ (_, _, tl, rto,_) ->
+       <:extension_constructor< $_uid:_$ of $_list:_$ . $_list:tl$ $_rto:rto$ $_algattrs:_$ >>
+(*
+       MLast.EcTuple _ (_, _, _, tl, rto,_)
+ *)
+ ->
        match tl with
          [ <:vala< [] >> -> False
          | _ -> True ]
@@ -718,10 +722,15 @@ value type_extension loc pc te =
 
 value has_cons_with_params vdl =
   List.exists
-    (fun (_, _, tl, rto,_) ->
+    (fun [ <:constructor< $_uid:_$ of $_list:_$ . $_list:tl$ $_rto:rto$ $_algattrs:_$ >>
+(*
+(_, _, _, tl, rto,_)
+ *)
+->
        match tl with
        [ <:vala< [] >> -> False
-       | _ -> True ])
+       | _ -> True ]
+    ])
     vdl
 ;
 


### PR DESCRIPTION
But they will work backlevel, b/c they're really just converting AST
patterns into quotations.