### PR TITLE
fixes for compatibility with camlp5 8.03.00

### DIFF
--- a/p5scm.opam
+++ b/p5scm.opam
@@ -15,6 +15,7 @@ depends: [
   "menhir" {>= "20201214"}
   "cppo" {>= "1.6.6"}
   "camlp5" {>= "8.01.00"}
+  "not-ocamlfind"
   "sexp_pretty" {>= "v0.14.0"}
   "ppx_sexp_conv" {>= "v0.14.0"}
   "utop" {>= "2.7.0"}

--- a/src/lib/camlp5/Makefile
+++ b/src/lib/camlp5/Makefile
@@ -7,19 +7,24 @@ VERSION = $(shell ocamlc get_version.ml -o get_version; ./get_version)
 
 pa_scheme:
 	cppo pa_schemer.cppo.ml -o pa_schemer.ml
-	camlp5 pa_r.cmo pa_rp.cmo pa_extend.cmo q_MLast.cmo pr_o.cmo pa_schemer.ml -o ../pa_scheme.ml
+	not-ocamlfind preprocess -package camlp5.extend,camlp5.quotations,camlp5.pr_o -syntax camlp5r pa_schemer.ml > ../pa_scheme.ml
+##	camlp5 pa_r.cmo pa_rp.cmo pa_extend.cmo q_MLast.cmo pr_o.cmo pa_schemer.ml -o ../pa_scheme.ml
 
 pr_o:
 	cppo pr_o.cppo.ml -o pr_o.ml
-	camlp5 pa_r.cmo pa_rp.cmo pa_macro.cmo q_MLast.cmo pa_extfun.cmo pa_extprint.cmo pa_pprintf.cmo pr_o.cmo pr_o.ml -o ../pr_o.ml
+	not-ocamlfind preprocess -package camlp5.extend,camlp5.macro,camlp5.quotations,camlp5.extfun,camlp5.extprint,camlp5.pprintf,camlp5.pr_o -syntax camlp5r pr_o.ml > ../pr_o.ml
+#	camlp5 pa_r.cmo pa_rp.cmo pa_macro.cmo q_MLast.cmo pa_extfun.cmo pa_extprint.cmo pa_pprintf.cmo pr_o.cmo pr_o.ml -o ../pr_o.ml
 
 pr_dump:
 	cppo pr_dump.cppo.ml -o pr_dump.ml
-	camlp5 pa_r.cmo pr_o.cmo pr_dump.ml -o ../pr_dump.ml
+	not-ocamlfind preprocess -package camlp5.pr_o -syntax camlp5r pr_dump.ml > ../pr_dump.ml
+#	camlp5 pa_r.cmo pr_o.cmo pr_dump.ml -o ../pr_dump.ml
 
 exparser:
-	camlp5 pa_r.cmo q_MLast.cmo pr_o.cmo exparser.ml -o ../exparser.ml
-	camlp5 pa_r.cmo q_MLast.cmo pr_o.cmo exparser.mli -o ../exparser.mli
+	not-ocamlfind preprocess -package camlp5.quotations,camlp5.pr_o -syntax camlp5r exparser.ml > ../exparser.ml
+	not-ocamlfind preprocess -package camlp5.quotations,camlp5.pr_o -syntax camlp5r exparser.mli > ../exparser.mli
+#	camlp5 pa_r.cmo q_MLast.cmo pr_o.cmo exparser.ml -o ../exparser.ml
+#	camlp5 pa_r.cmo q_MLast.cmo pr_o.cmo exparser.mli -o ../exparser.mli
 
 pconfig:
 	cp ./ocaml_stuff/$(VERSION)/utils/pconfig.ml ../pconfig.ml


### PR DESCRIPTION
For a while, instead of calling "camlp5 pr_xx.cmo pa_yy.cmo etc", you can use "not-ocamlfind preprocess" and give it Findlib package-names.  This is more upward-compatible, and hides the details of exactly how camlp5 is invoked.

I've modified your Makefiles to do this, and left the original invocations in comments.  Everything appears to build, and tests seem to pass.  Though I'm not sure about the latter.

The original "pr_o.cmo" now needs a preliminary package "o_keywords.cmo" which contains a list of all the keywords of the "o" syntax.  That file is generated mechanically, so it can't be included textually in "pr_o.ml".  Hence why it's better to require the package "camlp5.pr_o" rather than loading the file "pr_o.cmo".